### PR TITLE
Rework pedalpcb-build-docs CTA: primary callout + button, deep-link to /pcbs?source=PEDALPCB

### DIFF
--- a/collections/_blog/pedalpcb-build-docs.md
+++ b/collections/_blog/pedalpcb-build-docs.md
@@ -21,8 +21,8 @@ header:
 
 ---
 
-**This table grew up.** Every PedalPCB board below — plus AION FX and Madbean — is now part of [Pedal Builder](https://builder.pachydermpedals.com), a free, live, searchable database. Search any component to see every PCB that uses it, browse full bills of materials, and follow links straight to each build doc. No account needed.
-{: .notice--info}
+**This list stopped updating in 2024. Search the one that didn't.** Same PedalPCB boards below — plus AION FX and Madbean — searchable by name, always current, with the schematic, wiring diagram, drill template, and full BOM one click away. Free, no account needed. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--primary .btn--large}
+{: .notice--primary}
 
 Let me start off by saying I love the PedalPCB community. The forum is an excellent place to get help, show off, and talk about pedals and building. I would classify pedalPCB as being more for the intermediate and above pedal builder. I believe that most of the board are based on traces that they have done themselves. They are meant to be accurate representations of the pedals they are compared to. 
 
@@ -42,6 +42,9 @@ The people on the board are great at helping out as well, and Mr. PedalPCB is ve
 
 **Updated:** May 11, 2024
 {: .notice--success }
+
+**Don't scroll — search it.** Same boards, searchable by name. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--primary}
+{: .notice--primary}
 
 | Name | Compare To | SKU | Build Doc |
 |------|------------|-----|-----------|


### PR DESCRIPTION
## Summary
The `/blog/pedalpcb-build-docs/` page's Pedal Builder CTA wasn't converting. Two problems:
- It was one sentence inside a `.notice--info` box — the same pale, low-contrast style used 21 other places on the site, easy to skim past.
- The link went to the bare `builder.pachydermpedals.com` homepage instead of the PCBs list, so even a click didn't land on what the reader came for.

## Changes
- New copy leads with the honest, specific hook: this table stopped updating in May 2024, Pedal Builder didn't. Framed around searching by **board name** (not component lookup — this page's visitors already know which board they want).
- Styled as `.notice--primary` (unused elsewhere on the site, so it reads as a distinct call-to-action rather than blending in with the other info/warning/success asides) with a real `.btn .btn--primary` button, matching the button convention already used in `_includes/ppcollection.html`.
- Link target is now `https://builder.pachydermpedals.com/pcbs?source=PEDALPCB` — a working deep-link filter that lands the reader directly on just the PedalPCB boards, searchable by name.
- Added a second, shorter version of the same callout directly above the table, for readers who scroll past the intro straight to the table (likely most of them, given this is a 27-minute read).

## Test plan
- [x] Matched the `{: .notice--primary}` / `{: .btn .btn--primary}` kramdown IAL syntax exactly against this repo's existing working examples (`.notice--info`/`.notice--warning`/`.notice--success` used across `collections/_pedals/*.md` and `collections/_blog/*.md`; `.btn` used in `_includes/ppcollection.html`), including the blank-line-after-IAL requirement.
- [x] Confirmed `source=PEDALPCB` is a valid filter value and `/pcbs` reads it from the URL (pedal-builder-experiment frontend source).
- [ ] No local Jekyll toolchain available in this environment to render a preview — recommend eyeballing the diff or checking a deploy preview before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)