### PR TITLE
Follow-up: pedalpcb-build-docs CTA — swap gray (primary) callout/button to blue (info)

### DIFF
--- a/collections/_blog/pedalpcb-build-docs.md
+++ b/collections/_blog/pedalpcb-build-docs.md
@@ -21,8 +21,8 @@ header:
 
 ---
 
-**This list stopped updating in 2024. Search the one that didn't.** Same PedalPCB boards below — plus AION FX and Madbean — searchable by name, always current, with the schematic, wiring diagram, drill template, and full BOM one click away. Free, no account needed. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--primary .btn--large}
-{: .notice--primary}
+**This list stopped updating in 2024. Search the one that didn't.** Same PedalPCB boards below — plus AION FX and Madbean — searchable by name, always current, with the schematic, wiring diagram, drill template, and full BOM one click away. Free, no account needed. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--info .btn--large}
+{: .notice--info}
 
 Let me start off by saying I love the PedalPCB community. The forum is an excellent place to get help, show off, and talk about pedals and building. I would classify pedalPCB as being more for the intermediate and above pedal builder. I believe that most of the board are based on traces that they have done themselves. They are meant to be accurate representations of the pedals they are compared to. 
 
@@ -43,8 +43,8 @@ The people on the board are great at helping out as well, and Mr. PedalPCB is ve
 **Updated:** May 11, 2024
 {: .notice--success }
 
-**Don't scroll — search it.** Same boards, searchable by name. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--primary}
-{: .notice--primary}
+**Don't scroll — search it.** Same boards, searchable by name. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--info}
+{: .notice--info}
 
 | Name | Compare To | SKU | Build Doc |
 |------|------------|-----|-----------|


### PR DESCRIPTION
## Summary
Quick color follow-up to #71 (merged). `.notice--primary` / `.btn--primary` render as this theme's muted default-skin **gray**, not a brand accent — doesn't stand out against the page. Per feedback, swapping to `.notice--info` / `.btn--info` (**blue**), which also stays visually distinct from the existing `.notice--success` (green) "Updated" line lower on the same page.

Only change: `--primary` → `--info` on both callouts (top intro box + the short one above the table). No copy or link changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)