### PR TITLE
Apply pedalpcb-build-docs CTA treatment to madbean-build-docs (info callout + button, /pcbs?source=MADBEAN)

### DIFF
--- a/collections/_blog/madbean-build-docs.md
+++ b/collections/_blog/madbean-build-docs.md
@@ -21,7 +21,7 @@ header:
 
 ---
 
-**This table grew up.** The Madbean projects below — plus PedalPCB and AION FX — are now part of [Pedal Builder](https://builder.pachydermpedals.com), a free, live, searchable database. Search any component to see every PCB that uses it, browse full bills of materials, and follow links straight to each build doc. No account needed.
+**This list stopped updating in 2021. Search the one that didn't.** Same Madbean boards below — plus PedalPCB and AION FX — searchable by name, always current, with the schematic, wiring diagram, drill template, and full BOM one click away. Free, no account needed. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=MADBEAN){: .btn .btn--info .btn--large}
 {: .notice--info}
 
 Madbean Pedals has projects for a all levels of builder. From beginner to expert and beyond. Some of their build are really tough and they will challenge you in different ways. Fot me, Madbean has the best build documents. They are packed with information about the pedal, the build, where to source parts, and steps for calibration if needed. The selection of circuits is not largest, be there are some excellent choices. 
@@ -34,6 +34,9 @@ I also like the selection of VFE boards that they have to offer. These are no cl
 {: .notice--success }
 
 All boards can be purchase from the [Madbean Pedals Projects Page](https://www.madbeanpedals.com/projects/).
+
+**Don't scroll — search it.** Same boards, searchable by name. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=MADBEAN){: .btn .btn--info}
+{: .notice--info}
 
 | Name | Inspired By | Level | PDF | ZIP | Schema |
 |------|------------|-------|-----|-----|-------|


### PR DESCRIPTION
## Summary
Same rework as #71/#72, applied to the Madbean sibling page (https://www.pachydermpedals.com/blog/madbean-build-docs/), which had the identical old CTA pattern (one sentence in a `.notice--info` box, linking to the bare builder homepage).

## Changes
- New copy: this table stopped updating in **July 2021** (even staler than the PedalPCB page's May 2024), framed around searching by board name.
- Stayed on `.notice--info` / `.btn--info` (blue) from the start — the earlier PR briefly used `.notice--primary`/`.btn--primary`, which renders as this theme's muted default-skin gray, not a brand color.
- Link target: `https://builder.pachydermpedals.com/pcbs?source=MADBEAN` (verified MADBEAN is a populated PCBSource filter, and sample Madbean PCBs carry schematic/wiring-diagram/drill-template GCS paths, so the feature claim is accurate for this source too).
- Added the same second, shorter callout directly above the table.

## Test plan
- [x] Matched existing working `.notice--info`/`.btn` kramdown IAL syntax already used elsewhere in this repo (including this same page's own pre-existing `.notice--success` "Updated" block), with the required blank line after each IAL.
- [x] Confirmed `source=MADBEAN` is a valid, populated `/pcbs` filter value in the pedal-builder-experiment frontend source, and spot-checked the production API to confirm Madbean PCBs carry the diagram/BOM data this copy claims.
- [ ] No local Jekyll toolchain in this environment; recommend a quick visual check after merge (as done for #71/#72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)