### PR TITLE
Fix invisible CTA button text on pedalpcb/madbean build-doc pages

### DIFF
--- a/collections/_blog/madbean-build-docs.md
+++ b/collections/_blog/madbean-build-docs.md
@@ -21,7 +21,7 @@ header:
 
 ---
 
-**This list stopped updating in 2021. Search the one that didn't.** Same Madbean boards below — plus PedalPCB and AION FX — searchable by name, always current, with the schematic, wiring diagram, drill template, and full BOM one click away. Free, no account needed. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=MADBEAN){: .btn .btn--info .btn--large}
+**This list stopped updating in 2021. Search the one that didn't.** Same Madbean boards below — plus PedalPCB and AION FX — searchable by name, always current, with the schematic, wiring diagram, drill template, and full BOM one click away. Free, no account needed. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=MADBEAN){: .btn .btn--info .btn--large style="color:#fff"}
 {: .notice--info}
 
 Madbean Pedals has projects for a all levels of builder. From beginner to expert and beyond. Some of their build are really tough and they will challenge you in different ways. Fot me, Madbean has the best build documents. They are packed with information about the pedal, the build, where to source parts, and steps for calibration if needed. The selection of circuits is not largest, be there are some excellent choices. 
@@ -35,7 +35,7 @@ I also like the selection of VFE boards that they have to offer. These are no cl
 
 All boards can be purchase from the [Madbean Pedals Projects Page](https://www.madbeanpedals.com/projects/).
 
-**Don't scroll — search it.** Same boards, searchable by name. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=MADBEAN){: .btn .btn--info}
+**Don't scroll — search it.** Same boards, searchable by name. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=MADBEAN){: .btn .btn--info style="color:#fff"}
 {: .notice--info}
 
 | Name | Inspired By | Level | PDF | ZIP | Schema |

--- a/collections/_blog/pedalpcb-build-docs.md
+++ b/collections/_blog/pedalpcb-build-docs.md
@@ -21,7 +21,7 @@ header:
 
 ---
 
-**This list stopped updating in 2024. Search the one that didn't.** Same PedalPCB boards below — plus AION FX and Madbean — searchable by name, always current, with the schematic, wiring diagram, drill template, and full BOM one click away. Free, no account needed. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--info .btn--large}
+**This list stopped updating in 2024. Search the one that didn't.** Same PedalPCB boards below — plus AION FX and Madbean — searchable by name, always current, with the schematic, wiring diagram, drill template, and full BOM one click away. Free, no account needed. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--info .btn--large style="color:#fff"}
 {: .notice--info}
 
 Let me start off by saying I love the PedalPCB community. The forum is an excellent place to get help, show off, and talk about pedals and building. I would classify pedalPCB as being more for the intermediate and above pedal builder. I believe that most of the board are based on traces that they have done themselves. They are meant to be accurate representations of the pedals they are compared to. 
@@ -43,7 +43,7 @@ The people on the board are great at helping out as well, and Mr. PedalPCB is ve
 **Updated:** May 11, 2024
 {: .notice--success }
 
-**Don't scroll — search it.** Same boards, searchable by name. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--info}
+**Don't scroll — search it.** Same boards, searchable by name. [Find your board →](https://builder.pachydermpedals.com/pcbs?source=PEDALPCB){: .btn .btn--info style="color:#fff"}
 {: .notice--info}
 
 | Name | Compare To | SKU | Build Doc |


### PR DESCRIPTION
## Summary
The "Find your board" buttons added in #71/#72/#73 render with **invisible text** — confirmed live via `getComputedStyle`, the button's `color` computes to the exact same value as its `background-color`. Not a design/taste issue, a real bug.

## Root cause
Confirmed with a live-DOM test on the deployed site (create an identical `.btn.btn--info` element, compare outside vs. inside a `.notice--info` box):
- Outside a notice: `color: rgb(255,255,255)` on `background: rgb(59,156,186)` — correct, readable.
- Inside a `.notice--info` box (where these buttons live): `color` collapses to `rgb(59,156,186)` — matches the background exactly.

Minimal Mistakes styles descendant links inside `.notice--info` to match the notice's theme color. That rule wins the cascade over `.btn`'s own white-text rule when a button is nested inside the notice — which all 4 of these CTA buttons are, by design (button-inside-a-callout-box). Confirmed this isn't sitewide: the Twitter/Facebook/Reddit share buttons on the same pages, outside any notice, render correct white text.

## Fix
Add `style="color:#fff"` to each button's kramdown IAL — inline styles win on specificity regardless of ancestor selectors. Verified this exact fix live (appended a test node with the override inside the real `.notice--info` box) before applying it to the file.

## Test plan
- [x] Reproduced and root-caused against the live site, not guessed.
- [x] Verified the fix wins the cascade live before applying.
- [ ] Recommend a quick visual check after merge to confirm the button text reads white against the blue background on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)